### PR TITLE
Fix POM configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,4 @@
 # In each subsection folders are ordered first by depth, then alphabetically.
 # This should make it easy to add new rules without breaking existing ones.
 
-*   @quarkiverse/quarkiverse-infinispan
+*   @quarkiverse/quarkiverse-infinispan-embedded

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -8,12 +8,12 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>quarkus-infinispan-embedded-extension-parent</artifactId>
-    <name>Quarkus Infinispan Embedded :: Extension Parent</name>
+    <name>Quarkus - Infinispan - Embedded :: Extension Parent</name>
     <packaging>pom</packaging>
 
     <modules>
         <module>deployment</module>
         <module>runtime</module>
     </modules>
-    
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,9 @@
     <artifactId>quarkus-infinispan-embedded-parent</artifactId>
     <version>999-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>Quarkus Infinispan Embedded - Parent</name>
+    <name>Quarkus - Infinispan - Embedded :: Parent</name>
     <modules>
         <module>extension</module>
-        <module>integration-tests</module>
-        <module>sample</module>
-        <module>docs</module>
     </modules>
     <scm>
         <connection>scm:git:git@github.com:quarkiverse/quarkus-infinispan-embedded.git</connection>
@@ -119,6 +116,7 @@
                 </property>
             </activation>
             <modules>
+                <module>integration-tests</module>
                 <module>sample</module>
             </modules>
         </profile>


### PR DESCRIPTION
- Update project naming convention in POM files to follow the same convention in the extension.
- Remove modules from the default reactor since they are already included in the profiles.
